### PR TITLE
remove fontWeight from Card doc example

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -150,7 +150,6 @@ Extension of the Box component with more style props for common variations
 ```.jsx
 <Card
   fontSize={6}
-  fontWeight='bold'
   width={[ 1, 1, 1/2 ]}
   p={5}
   my={5}


### PR DESCRIPTION
As far as I can tell, Card doesn't expose the fontWeight prop (please correct me if I'm wrong!).