### PR TITLE
Remove css prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,6 @@ import {
   variant,
 } from 'styled-system'
 
-const css = props => props.css
 const themed = key => props => props.theme[key]
 
 export const Box = styled('div')({
@@ -44,8 +43,7 @@ export const Box = styled('div')({
   flex,
   order,
   alignSelf,
-  themed('Box'),
-  css
+  themed('Box')
 )
 
 Box.propTypes = {
@@ -53,6 +51,9 @@ Box.propTypes = {
   ...width.propTypes,
   ...fontSize.propTypes,
   ...color.propTypes,
+  ...flex.propTypes,
+  ...order.propTypes,
+  ...alignSelf.propTypes,
 }
 
 export const Flex = styled(Box)({


### PR DESCRIPTION
The `css` prop is now supported in babel-plugin-styled-components and isn't really necessary in Rebass anymore