### PR TITLE
Upgrade styled-system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10533,9 +10533,9 @@
       }
     },
     "styled-system": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-3.1.11.tgz",
-      "integrity": "sha512-d0p32F7Y55uRWNDb1P0JcIiGVi13ZxiSCvn8zNS68exAKW9Q5jp+IGTXUIavQOD/J8r3tydtE3vRk8Ii2i39HA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-3.2.1.tgz",
+      "integrity": "sha512-ag0Yp7UeVHHc3t+1uM3jvlljaZYzwqpbJ8hMrFvpaKfUd8xsB9JeQXLwMpEsz8iLx8Lz/+9j0coWFZjmw8MogQ==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "prop-types": "^15.6.2"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "Brent Jackson",
   "license": "MIT",
   "dependencies": {
-    "styled-system": "^3.1.11"
+    "styled-system": "^3.2.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.5",


### PR DESCRIPTION
I was wanting to use the breakpoints as object feature that was released in 3.1.12 of `styled-system` so I was hoping to get this upgraded. 