### PR TITLE
Link extends Text

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ Heading.defaultProps = {
   fontWeight: 'bold',
 }
 
-export const Link = styled(Box)(
+export const Link = styled(Text)(
   themed('Link')
 )
 


### PR DESCRIPTION
Apologies if this idea has been discussed in other issues or PRs -- the primitive names being so generic makes searching for specific issues pretty difficult.

There are times I want a link to have some sort of typographic contrast to surrounding text (like a bolder `font-weight`, for example). While this can be accomplished now with `<Text as="a" fontWeight="bold"...`, updating the `Link` primitive to extend `Text` feels like the cleaner DX solution. It also makes more semantic sense: a link is typically a piece of text, not a layout box.

If this gets merged I'm more than happy to submit a PR over at the (new?) docs repo to reflect.