### PR TITLE
Refer to emotion-theming instead of @emotion/theming

### DIFF
--- a/packages/docs/src/pages/getting-started.mdx
+++ b/packages/docs/src/pages/getting-started.mdx
@@ -17,14 +17,14 @@ You can add a theme to your application with a `ThemeProvider` component and by 
 For this guide, use the Emotion `ThemeProvider` with the default Rebass preset theme.
 
 ```sh
-npm i @rebass/preset @emotion/theming
+npm i @rebass/preset emotion-theming
 ```
 
 Wrap your application with the `ThemeProvider` component.
 
 ```jsx
 import React from 'react'
-import { ThemeProvider } from '@emotion/theming'
+import { ThemeProvider } from 'emotion-theming'
 import theme from '@rebass/preset'
 
 export default props =>
@@ -130,7 +130,7 @@ Since Rebass follows the [Theme Specification][], any theme built for use with [
 
 ```jsx
 import React from 'react'
-import { ThemeProvider } from '@emotion/theming'
+import { ThemeProvider } from 'emotion-theming'
 
 const theme = {
   fontSizes: [

--- a/packages/docs/src/pages/theming.mdx
+++ b/packages/docs/src/pages/theming.mdx
@@ -12,13 +12,13 @@ All colors, typographic styles, layout styles, and component variants can be com
 
 To apply themes to Rebass components, add a [ThemeProvider][] component to the root of your application and pass a `theme` object as a prop.
 
-If you're using Emotion by itself, install the `@emotion/theming` package.
+If you're using Emotion by itself, install the `emotion-theming` package.
 If you're using Rebass with [Theme UI][], use its `ThemeProvider` or the `gatsby-plugin-theme-ui` package.
 
 ```jsx
 import React from 'react'
 import theme from './theme'
-import { ThemeProvider } from '@emotion/theming'
+import { ThemeProvider } from 'emotion-theming'
 // or for use with Theme UI:
 // import { ThemeProvider } from 'theme-ui'
 
@@ -93,7 +93,7 @@ npm i @rebass/preset
 
 ```jsx
 import React from 'react'
-import { ThemeProvider } from '@emotion/theming'
+import { ThemeProvider } from 'emotion-theming'
 import preset from '@rebass/preset'
 
 export default props =>

--- a/packages/preset-material/README.md
+++ b/packages/preset-material/README.md
@@ -13,7 +13,7 @@ For general usage with [Emotion][], pass the theme preset to Emotion's `ThemePro
 
 ```jsx
 import React from 'react'
-import { ThemeProvider } from '@emotion/theming'
+import { ThemeProvider } from 'emotion-theming'
 import theme from '@rebass/preset-material'
 
 export default props =>

--- a/packages/preset/README.md
+++ b/packages/preset/README.md
@@ -13,7 +13,7 @@ For general usage with [Emotion][], pass the theme preset to Emotion's `ThemePro
 
 ```jsx
 import React from 'react'
-import { ThemeProvider } from '@emotion/theming'
+import { ThemeProvider } from 'emotion-theming'
 import theme from '@rebass/preset'
 
 export default props =>

--- a/packages/reflexbox/README.md
+++ b/packages/reflexbox/README.md
@@ -75,15 +75,15 @@ Note: to opt-out of theme-based styles, use the `css` prop instead, which will n
 
 Because Reflexbox follows the [Theme Specification][], all themes built for use with [Styled System][], [Theme UI][], or other related libraries are compatible with Reflexbox.
 
-To add a theme to an application, import the `ThemeProvider` component from `@emotion/theming` and pass a custom theme object in.
+To add a theme to an application, import the `ThemeProvider` component from `emotion-theming` and pass a custom theme object in.
 
 ```sh
-npm i @emotion/theming
+npm i emotion-theming
 ```
 
 ```jsx
 import React from 'react'
-import { ThemeProvider } from '@emotion/theming'
+import { ThemeProvider } from 'emotion-theming'
 import { Flex, Box } from 'reflexbox'
 
 const theme = {


### PR DESCRIPTION
The @emotion/theming package 404s on npm. emotion-theming is the correct package name.

Excited to check out rebass v4! 🙌 