### PR TITLE
reflexbox: Move react to peerDependencies

### DIFF
--- a/examples/sandbox-v3/package.json
+++ b/examples/sandbox-v3/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "name": "sandbox",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "dependencies": {
     "react": "^16.4.0",
     "react-dom": "^16.4.2",
     "react-scripts": "^3.0.1",
-    "rebass": "^4.0.5",
+    "rebass": "^4.0.6",
     "styled-components": "^4.0.0"
   },
   "scripts": {

--- a/examples/sandbox/package.json
+++ b/examples/sandbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rebass-sandbox",
   "private": true,
-  "version": "4.0.5",
+  "version": "4.0.6",
   "main": "index.js",
   "license": "MIT",
   "scripts": {
@@ -13,7 +13,7 @@
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-scripts": "^3.1.1",
-    "rebass": "^4.0.5",
+    "rebass": "^4.0.6",
     "styled-components": "^4.3.2"
   },
   "browserslist": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.5",
+  "version": "4.0.6",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": [

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "docs",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "main": "index.js",
   "license": "MIT",
   "scripts": {
@@ -16,7 +16,7 @@
     "@jxnblk/react-live": "^2.1.2-1",
     "@mdx-js/mdx": "^1.1.4",
     "@mdx-js/react": "^1.1.4",
-    "@rebass/forms": "^4.0.5",
+    "@rebass/forms": "^4.0.6",
     "@rebass/preset": "^4.0.5",
     "@rebass/preset-material": "^4.0.5",
     "@rebass/space": "^4.0.5",
@@ -33,7 +33,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.1",
-    "rebass": "^4.0.5",
+    "rebass": "^4.0.6",
     "remark-slug": "^5.1.2",
     "theme-ui": "^0.2.26"
   }

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@rebass/forms",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "scripts": {
     "prepare": "rebass-bundler"
   },
   "dependencies": {
-    "reflexbox": "^4.0.5"
+    "reflexbox": "^4.0.6"
   },
   "repository": "rebassjs/rebass",
   "bugs": {

--- a/packages/rebass/package.json
+++ b/packages/rebass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rebass",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "React primitive UI components built with Styled System",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
@@ -24,7 +24,7 @@
   "author": "Brent Jackson",
   "license": "MIT",
   "dependencies": {
-    "reflexbox": "^4.0.5"
+    "reflexbox": "^4.0.6"
   },
   "repository": "rebassjs/rebass",
   "bugs": {

--- a/packages/reflexbox/package.json
+++ b/packages/reflexbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflexbox",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "Responsive React grid system built with Styled System, with support for Emotion and Styled Components",
   "main": "dist/index.js",
   "keywords": [

--- a/packages/reflexbox/package.json
+++ b/packages/reflexbox/package.json
@@ -23,8 +23,10 @@
     "@emotion/styled": "^10.0.0",
     "@styled-system/css": "^5.0.0",
     "@styled-system/should-forward-prop": "^5.0.0",
-    "react": "^16.8.6",
     "styled-system": "^5.0.0"
+  },
+  "peerDependencies": {
+    "react": "^16.8.6"
   },
   "author": "Brent Jackson",
   "license": "MIT",


### PR DESCRIPTION
Having react on dependencies potentially bundles multiple react versions.
Therefore we can keep it in peerDependencies.