### PR TITLE
Set default heading variant

### DIFF
--- a/packages/rebass/src/index.js
+++ b/packages/rebass/src/index.js
@@ -16,13 +16,8 @@ export const Heading = forwardRef((props, ref) =>
     ref={ref}
     as='h2'
     tx='text'
+    variant='heading'
     {...props}
-    __css={{
-      fontSize: 4,
-      fontFamily: 'heading',
-      fontWeight: 'heading',
-      lineHeight: 'heading',
-    }}
   />
 )
 

--- a/packages/rebass/src/index.js
+++ b/packages/rebass/src/index.js
@@ -18,6 +18,12 @@ export const Heading = forwardRef((props, ref) =>
     tx='text'
     variant='heading'
     {...props}
+    __css={{
+      fontSize: 4,
+      fontFamily: 'heading',
+      fontWeight: 'heading',
+      lineHeight: 'heading',
+    }}
   />
 )
 


### PR DESCRIPTION
The docs say the `text.heading` variant is applied by default to `<Heading />`, but the variant wasn't present.