### PR TITLE
Export variant function

### DIFF
--- a/packages/reflexbox/src/index.js
+++ b/packages/reflexbox/src/index.js
@@ -13,7 +13,7 @@ import shouldForwardProp from '@styled-system/should-forward-prop'
 
 const sx = props => css(props.sx)(props.theme)
 const base = props => css(props.__css)(props.theme)
-const variant = ({
+export const variant = ({
   theme,
   variant,
   tx = 'variants',


### PR DESCRIPTION
I have a use case where I'd like a custom component to have a `variant` prop that behaves as it does in Rebass, but the component in question uses `className` in a nonstandard way, so doing something like `<Box as={MyComponent} ...` won't work.

If I could instead do `styled(MyComponent)(variant)`, I could receive the generated `className` and make it play nice with the nonstandard API.