### PR TITLE
Fix checkbox positioning

### DIFF
--- a/packages/forms/src/index.js
+++ b/packages/forms/src/index.js
@@ -249,7 +249,7 @@ export const Checkbox= forwardRef(({
       type='checkbox'
       {...props}
       sx={{
-        position: 'absolute',
+        position: 'fixed',
         opacity: 0,
         zIndex: -1,
         width: 1,

--- a/packages/forms/test/__snapshots__/index.js.snap
+++ b/packages/forms/test/__snapshots__/index.js.snap
@@ -11,7 +11,7 @@ exports[`Checkbox renders 1`] = `
   box-sizing: border-box;
   margin: 0;
   min-width: 0;
-  position: absolute;
+  position: fixed;
   opacity: 0;
   z-index: -1;
   width: 1px;


### PR DESCRIPTION
Hi there! Encountered a little bug with the Checkbox's hidden `input` element positioning. When set to `absolute`, it can be placed below the content on the page when using the checkboxes in a child scrolling container with `overflow: auto`. This can be fixed in a couple ways, setting `top: 0` works as well, but I thought that `position: fixed` made more sense.

## To replicate:
```
import { Checkbox, Label } from '@rebass/forms';
import React from 'react';
import { Box, Flex } from 'rebass';

const CheckboxExample = () => {
  const checkboxes = [];

  for (let i = 0; i < 50; i += 1) {
    checkboxes.push(
      <Label key={i}>
        <Checkbox />
        Checkbox
      </Label>,
    );
  }
  return (
    <Box height="100vh" bg="lightgrey">
      <Flex flexDirection="column" height="100%">
        <Box bg="blue" color="white" p={3}>
          Navbar
        </Box>
        <Box overflow="auto">{checkboxes}</Box>
      </Flex>
    </Box>
  );
};

export default CheckboxExample;
```

Notice that the bottom scroll container scrolls, but when you reach the bottom you're able to continue scrolling. If you inspect the `input` elements in the lower checkboxes you'll see that they exist off the bottom of the page, allowing the page to scroll past our intended container height!

<img width="1679" alt="Screen Shot 2021-02-21 at 9 33 47 AM" src="https://user-images.githubusercontent.com/12277245/108628268-f3eeeb80-7427-11eb-94db-b884c8c72a9f.png">

Changing the positioning on the "hidden" checkbox `input` element to `fixed` results in the correct placement of the `input`s and the expected container scroll behavior.

