### PR TITLE
Update emotion-theming package to @emotion/react

### DIFF
--- a/packages/docs/src/pages/theming.mdx
+++ b/packages/docs/src/pages/theming.mdx
@@ -15,7 +15,7 @@ If you're using Rebass with [Theme UI][], use its `ThemeProvider` or the `gatsby
 ```jsx
 import React from 'react'
 import theme from './theme'
-import { ThemeProvider } from 'emotion-theming'
+import { ThemeProvider } from '@emotion/react'
 // or for use with Theme UI:
 // import { ThemeProvider } from 'theme-ui'
 


### PR DESCRIPTION
emotion-theming is now called @emotion/react
reference - https://github.com/emotion-js/emotion/tree/main/packages/react#emotionreact